### PR TITLE
optimize to 1 query instead of sessions count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules
 .pnp
 .pnp.js
+package-lock.json
+yarn.lock
 
 # Testing
 coverage

--- a/backend/app/api/study_plans.py
+++ b/backend/app/api/study_plans.py
@@ -130,10 +130,12 @@ async def get_session_questions(
                 detail="You don't have access to this session"
             )
 
-        # Fetch all questions for the session
+        # Fetch all questions for the session (optimized - only needed fields)
         questions_response = db.table("session_questions").select(
-            "*, questions(*), topics(id, name)"
-        ).eq("session_id", session_id).execute()
+            "id, session_id, question_id, topic_id, display_order, status, "
+            "questions(id, stem, difficulty, question_type, answer_options, correct_answer), "
+            "topics(id, name)"
+        ).eq("session_id", session_id).order("display_order").execute()
 
         questions = []
         for sq in questions_response.data:


### PR DESCRIPTION
study plan 4-5 seconds
practice sessions 1-2 seconds

fix:

optimize to 1 query

before:

for session in sessions:
    questions = fetch(session.id)  # Easy to understand
    session["topics"] = process(questions)
fix:

all_questions = fetch_all(session_ids)  # Need to group manually
grouped = group_by_session(all_questions)  # Extra logic
for session in sessions:
    session["topics"] = grouped[session.id]