### PR TITLE
previous button in practice session

### DIFF
--- a/backend/app/api/study_plans.py
+++ b/backend/app/api/study_plans.py
@@ -132,7 +132,7 @@ async def get_session_questions(
 
         # Fetch all questions for the session (optimized - only needed fields)
         questions_response = db.table("session_questions").select(
-            "id, session_id, question_id, topic_id, display_order, status, "
+            "id, session_id, question_id, topic_id, display_order, status, user_answer, "
             "questions(id, stem, difficulty, question_type, answer_options, correct_answer), "
             "topics(id, name)"
         ).eq("session_id", session_id).order("display_order").execute()
@@ -144,7 +144,8 @@ async def get_session_questions(
                 "question": sq["questions"],
                 "topic": sq["topics"],
                 "status": sq["status"],
-                "display_order": sq["display_order"]
+                "display_order": sq["display_order"],
+                "user_answer": sq.get("user_answer")  # Include the user's submitted answer
             })
 
         return {
@@ -247,7 +248,8 @@ async def submit_answer(
         # Update session_question record
         update_data = {
             "status": answer_data.status,
-            "answered_at": "now()"
+            "answered_at": "now()",
+            "user_answer": user_answer  # Save the user's answer to the database
         }
 
         db.table("session_questions").update(update_data).eq(

--- a/backend/supabase/migrations/011_add_user_answer_column.sql
+++ b/backend/supabase/migrations/011_add_user_answer_column.sql
@@ -1,0 +1,12 @@
+-- Add user_answer column to session_questions table to store submitted answers
+
+ALTER TABLE session_questions 
+ADD COLUMN user_answer JSONB DEFAULT NULL;
+
+-- Add index for queries that filter by user_answer
+CREATE INDEX idx_session_questions_user_answer ON session_questions(session_id) 
+WHERE user_answer IS NOT NULL;
+
+-- Comment
+COMMENT ON COLUMN session_questions.user_answer IS 'Stores the user submitted answer as an array of strings (JSONB format)';
+


### PR DESCRIPTION
Backend:
Answer persistence: Save/return user_answer in session_questions table
Migration: Added user_answer column to database

Frontend:
Previous button: Navigate back through questions
Smart navigation: Show answered questions as read-only with feedback
Load saved answers: Populate answers from backend on page load
Result: Topics display correctly, answers persist across sessions, navigation works both ways.